### PR TITLE
Simple Carousel right slide button fixed

### DIFF
--- a/Components/Carousels/Simple-Carousel/style.css
+++ b/Components/Carousels/Simple-Carousel/style.css
@@ -195,14 +195,26 @@ li {
     outline: 0;
 }
 
-.carousel::before,
-.carousel__prev {
+.carousel__next,
+.carousel__prev{
+    height: 2.2rem;
+    width: 2.2rem;
+}
+
+.carousel::before{
     left: -1rem;
 }
 
-.carousel::after,
-.carousel__next {
+.carousel::after{
     right: -1rem;
+}
+
+.carousel__prev{
+    left:-0.1rem;
+}
+
+.carousel__next{
+    right:-0.1rem;
 }
 
 .carousel::before,


### PR DESCRIPTION
# Fixes Issue🛠️

<!-- Example: Closes #31 -->

Closes #

# Description👨‍💻 
Now the right slide button is working fine. Earlier it was working in a strange way as described in the Issue #17
<!--Please include a summary of the change and which issue is fixed.List any dependencies that are required for this change.-->

# Type of change📄

<!--Please delete options that are not relevant.-->

- [*] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)

# How this has been tested✅

<!--Please describe the tests that you ran to verify your changes.-->

# Checklist✅ 

- [*] My code follows the style guidelines of this project
- [*] I have performed a self-review of my own code
- [*] I have commented my code, particularly in hard-to-understand areas
- [*] I have added demonstration in the form of GIF/video file
- [*] I am an Open Source Contributor

# Screenshots/GIF📷
![BugFixed](https://github.com/Rakesh9100/Beautiify/assets/72575065/397de98d-b29e-400d-88b4-287cb6e27916)
