### PR TITLE
Hamburger menu fixed in contributors page

### DIFF
--- a/assets/css_files/contributor.css
+++ b/assets/css_files/contributor.css
@@ -63,7 +63,7 @@ body {
 }
 
 
-@media (min-width: 1000px){
+@media (min-width: 1400px){
     .footer{
         position: fixed;
         width: 100%;

--- a/assets/html_files/contributor.html
+++ b/assets/html_files/contributor.html
@@ -8,6 +8,7 @@
     <link rel="icon" href="../../assets/images/favicon.png" type="image/x-icon">
     <link rel="stylesheet" type="text/css" href="../../style.css" />
     <link rel="stylesheet" type="text/css" href="../css_files/contributor.css" />
+    <script src="../js_files/commonnav.js"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"/>
     <title>Contributors - Beautiify</title>
 </head>


### PR DESCRIPTION
# Fixes Issue🛠️

Closes #291 

# Description👨‍💻 

1. The Hamburger menu was not working on the contributor's page on small devices. Made fixes to the contributors.html file.
2. The footer was still overlapping in some cases, fixed it via this commit.

# Type of change📄

- [x] Bug fix (non-breaking change which fixes an issue)


# How this has been tested✅

1. The hamburger menu has been tested on small devices.
2. The footer has been checked and verified on all media screens via Chrome Developers Tool.

# Checklist✅ 

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added demonstration in the form of GIF/video file
- [x] I am an Open Source Contributor

# Screenshots/GIF📷:

![image](https://github.com/Rakesh9100/Beautiify/assets/33122840/7b89c9c5-d4ce-4cf8-8517-5ab0cf6d9814)
