### PR TITLE
Fixed the visibility of heading text in Contact page

### DIFF
--- a/assets/css_files/contact.css
+++ b/assets/css_files/contact.css
@@ -136,6 +136,7 @@ body {
     font-size: 30px;
     letter-spacing: 0.5px;
     text-shadow: 1px 1px 2px black, 1px 1px 2px white;
+    color: black;
 }
 
 .form-fields {


### PR DESCRIPTION
# Fixes Issue🛠️

Closes #843 

# Description👨‍💻 

I have fixed the visibility issue of the text on the Contact Us page which was not visible in the white mode.

# Type of change📄

<!--Please delete options that are not relevant.-->

- [x] Bug fix (non-breaking change which fixes an issue)

# How this has been tested✅

I did a manual check by changing into both dark and white modes to check if the color of the text remains constant in both the modes.

# Checklist✅ 

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I am an Open Source Contributor

# Screenshots/GIF📷

![Screenshot 2024-06-08 015252](https://github.com/Rakesh9100/Beautiify/assets/121930064/11f6a454-1866-4044-8278-41ae71b1f3e2)

![Screenshot 2024-06-08 015316](https://github.com/Rakesh9100/Beautiify/assets/121930064/fac363ab-a618-4675-b8ea-4ce1b7ec1c9a)
