### PR TITLE
Removed the extra space in About page

### DIFF
--- a/assets/css_files/about.css
+++ b/assets/css_files/about.css
@@ -27,7 +27,8 @@ body {
 section {
     display: flex;
     grid-template-columns: 1fr 1fr;
-    min-height: 70vh;
+    /* removed the extra space in about us page */
+    min-height: 70;
     width: 78vw;
     margin: 0 auto;
     margin-top: -50px;

--- a/assets/css_files/about.css
+++ b/assets/css_files/about.css
@@ -27,7 +27,6 @@ body {
 section {
     display: flex;
     grid-template-columns: 1fr 1fr;
-    /* removed the extra space in about us page */
     min-height: 70;
     width: 78vw;
     margin: 0 auto;


### PR DESCRIPTION
# Fixes Issue🛠️

Closes #876 

# Description👨‍💻 

The About page on the website had some extra space in the bottom. I removed the extra space in the about page.

# Type of change📄
- [x] Bug fix (non-breaking change which fixes an issue)

# How this has been tested✅
Tested locally.

# Checklist✅ 

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added demonstration in the form of GIF/video file
- [x] I am an Open Source Contributor (GSSOC'24)

# Screenshots/GIF📷

### BEFORE:

https://github.com/Rakesh9100/Beautiify/assets/93249125/e6dee60a-2671-401e-853b-542d87296375

### AFTER:

https://github.com/Rakesh9100/Beautiify/assets/93249125/4b7a3ea4-7e7d-4d14-80b4-f7029776883f
