### PR TITLE
Aligned the close button in Overlay Navigation Bar

### DIFF
--- a/Components/Navigation-Bars/Overlay-Navigation-Bar/index.html
+++ b/Components/Navigation-Bars/Overlay-Navigation-Bar/index.html
@@ -13,7 +13,6 @@
     <div class="overlay-container">
         <a href="#" class="close-btn" onclick="closeNav()">&times;</a>
         <div class="overlay">
-            <!-- <a href="#" class="close-btn" onclick="closeNav()">&times;</a> -->
             <a href="#">Home</a>
             <a href="#">About</a>
             <a href="#">Services</a>

--- a/Components/Navigation-Bars/Overlay-Navigation-Bar/index.html
+++ b/Components/Navigation-Bars/Overlay-Navigation-Bar/index.html
@@ -11,8 +11,9 @@
 
 <body>
     <div class="overlay-container">
+        <a href="#" class="close-btn" onclick="closeNav()">&times;</a>
         <div class="overlay">
-            <a href="#" class="close-btn" onclick="closeNav()">&times;</a>
+            <!-- <a href="#" class="close-btn" onclick="closeNav()">&times;</a> -->
             <a href="#">Home</a>
             <a href="#">About</a>
             <a href="#">Services</a>

--- a/Components/Navigation-Bars/Overlay-Navigation-Bar/style.css
+++ b/Components/Navigation-Bars/Overlay-Navigation-Bar/style.css
@@ -39,12 +39,20 @@ body {
 }
 
 .close-btn {
-    position: absolute;
+    /* position: absolute;
     top: 20px;
     right: 45px;
     font-size: 30px;
     cursor: pointer;
+    color: #818181; */
+    font-size: 30px;
+    cursor: pointer;
     color: #818181;
+    padding: 10px 20px;
+    position: absolute;
+    top: 20px;
+    right: 45px;
+    text-decoration: none;
 }
 
 

--- a/Components/Navigation-Bars/Overlay-Navigation-Bar/style.css
+++ b/Components/Navigation-Bars/Overlay-Navigation-Bar/style.css
@@ -39,12 +39,6 @@ body {
 }
 
 .close-btn {
-    /* position: absolute;
-    top: 20px;
-    right: 45px;
-    font-size: 30px;
-    cursor: pointer;
-    color: #818181; */
     font-size: 30px;
     cursor: pointer;
     color: #818181;
@@ -55,8 +49,6 @@ body {
     text-decoration: none;
 }
 
-
-
 .open-btn {
     font-size: 20px;
     cursor: pointer;
@@ -66,7 +58,6 @@ body {
     border: none;
     border-radius: 5px;
     transition: background-color 0.3s;
-
     position: fixed;
     top: 20px;
     left: 20px;


### PR DESCRIPTION
# Fixes Issue🛠️

<!-- Example: Closes #31 -->

Closes #802 

# Description👨‍💻 

The alignment of the close button in the overlay navigation bar of the "Navigation Bars" component was not proper. I have resolved that issue.

# Type of change📄

<!--Please delete options that are not relevant.-->

- [x] Bug fix (non-breaking change which fixes an issue)

# How this has been tested✅

I have opened my Live Server in order to test it after fixing the issue. Also I have checked that whether it is applicable to the all kinds of responsive pages or not and it is successful in that case as well.

# Checklist✅ 

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added demonstration in the form of GIF/video file
- [x] I am an Open Source Contributor

# Screenshots/GIF📷
![beautiify](https://github.com/Rakesh9100/Beautiify/assets/135226069/ad01919e-6ba1-4ad8-949e-573f02238650)

@Rakesh9100 Please review my PR.