### PR TITLE
Fixed the filtering logic not triggering with voice search

### DIFF
--- a/script.js
+++ b/script.js
@@ -159,7 +159,9 @@ if (SpeechRecognition) {
             newtranscript = transcript.endsWith('.') ? transcript.slice(0, -1) : transcript;
             console.log(newtranscript)
             searchBarInput.value = newtranscript;
-            searchBarInput.dispatchEvent(new Event("input", { bubbles: true }));
+            searchBarInput.dispatchEvent(new Event("input", {
+                bubbles: true
+            }));
         }
     }
 } else {


### PR DESCRIPTION
# Fixes Issue🛠️

Closes #1507 

# Description👨‍💻
- After setting `.value` with mic transcript, dispatched an `"input"` event to match the behavior of manual typing.
- This triggers the same filtering logic already bound to `"input"` listeners.
- Keeps all existing functions untouched. Works across all pages using shared search.

### File Touched

- `script.js`

# Type of Change📄

- [x] Bug fix (non-breaking change which fixes a bug)

# Checklist✅
- [x] I am an Open Source contributor
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project

# Screenshots/GIF📷

BEFORE 
![image](https://github.com/user-attachments/assets/420c777d-7356-452b-b1af-dc31aded9605)

AFTER 
![image](https://github.com/user-attachments/assets/82a1e14c-792a-49c8-926b-79ca738b0b0d)


